### PR TITLE
perf: load config settings only once at sign-in

### DIFF
--- a/js_config_sync_generator.py
+++ b/js_config_sync_generator.py
@@ -585,7 +585,10 @@ def generate_js_config_sync():
               handleFilterConfigChange(doc.data());
             }
           },
-          error => { console.error('Config listener failed (filters):', error); }
+          error => {
+            console.error('Config listener failed (filters):', error);
+            if (typeof updateSyncStatusUI === 'function') updateSyncStatusUI('error', error.message);
+          }
         );
 
       // Listen for export prefs changes
@@ -596,7 +599,10 @@ def generate_js_config_sync():
               handleExportPrefsChange(doc.data());
             }
           },
-          error => { console.error('Config listener failed (exportPrefs):', error); }
+          error => {
+            console.error('Config listener failed (exportPrefs):', error);
+            if (typeof updateSyncStatusUI === 'function') updateSyncStatusUI('error', error.message);
+          }
         );
 
       // Listen for UI prefs changes
@@ -607,7 +613,10 @@ def generate_js_config_sync():
               handleUIPrefsChange(doc.data());
             }
           },
-          error => { console.error('Config listener failed (uiPrefs):', error); }
+          error => {
+            console.error('Config listener failed (uiPrefs):', error);
+            if (typeof updateSyncStatusUI === 'function') updateSyncStatusUI('error', error.message);
+          }
         );
 
       // Listen for awareness config changes
@@ -618,7 +627,10 @@ def generate_js_config_sync():
               handleAwarenessConfigChange(doc.data());
             }
           },
-          error => { console.error('Config listener failed (awareness):', error); }
+          error => {
+            console.error('Config listener failed (awareness):', error);
+            if (typeof updateSyncStatusUI === 'function') updateSyncStatusUI('error', error.message);
+          }
         );
 
       // Add to global listeners array for cleanup

--- a/js_firebase_generator.py
+++ b/js_firebase_generator.py
@@ -894,24 +894,30 @@ def generate_js_firebase(firebase_config=None):
           updateSyncStatusUI('synced');
         }
 
-        // Load all config settings from cloud only when explicitly requested via options.loadConfigs
-        // Configs have real-time listeners for subsequent updates (see setupConfigRealtimeListeners)
-        if (options.loadConfigs) {
+        lastPullTime = Date.now(); // Track pull time for focus-based refresh
+      } catch (error) {
+        console.error('Pull from cloud failed:', error);
+        updateSyncStatusUI('error', error.message);
+        throw error;
+      }
+
+      // Load all config settings from cloud only when explicitly requested via options.loadConfigs
+      // Configs have real-time listeners for subsequent updates (see setupConfigRealtimeListeners)
+      // Separate try/catch so config load failure does not overwrite the 'synced' status above
+      if (options.loadConfigs) {
+        try {
           if (typeof loadAllConfigsFromCloud === 'function') {
             console.log('Loading config settings from cloud');
             await loadAllConfigsFromCloud();
           } else {
             console.error('loadAllConfigsFromCloud is not defined - config sync module may not be loaded');
           }
-        } else {
-          console.debug('Skipping config settings load (real-time listeners handle updates)');
+        } catch (configError) {
+          console.error('Config load from cloud failed:', configError);
+          updateSyncStatusUI('error', configError.message);
         }
-
-        lastPullTime = Date.now(); // Track pull time for focus-based refresh
-      } catch (error) {
-        console.error('Pull from cloud failed:', error);
-        updateSyncStatusUI('error', error.message);
-        throw error;
+      } else {
+        console.debug('Skipping config settings load (real-time listeners handle updates)');
       }
     }
 


### PR DESCRIPTION
## Summary
- Config tables (filters, exportPrefs, UIPrefs, awarenessConfig) were re-downloaded on every `pullFromCloud()` call
- Now configs load only at initial sign-in and manual sync via `loadConfigs: true` option
- Tab focus operations skip config download, reducing Firebase reads
- Real-time listeners continue to handle subsequent config updates automatically

Fixes #36

## Test plan
Since no automated tests exist for Firebase functionality, manual testing is required:

1. **Sign-in test:**
   - Open browser DevTools → Network tab → Filter by "firestore"
   - Sign in to tracker
   - Verify: 4 config document reads (filters, exportPrefs, uiPrefs, awareness) + progress collection

2. **Tab focus test:**
   - With tracker open, switch to another tab
   - Wait 5+ seconds, return to tracker tab
   - Verify: Only progress collection reads, NO config reads

3. **Manual sync test:**
   - Click "Sync Now" button
   - Verify: Progress collection reads AND config reads (all 4 config documents reloaded)