### PR TITLE
chore: standardize shell syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           set -eo pipefail
 
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
             # Tag push - extract version from tag
             VERSION="${GITHUB_REF#refs/tags/v}"
             TAG="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
## Summary
- Replace the single `[[ ]]` construct with POSIX-compatible `[ ]` on line 51 of `.github/workflows/release.yml`
- All other 35+ conditionals already use `[ ]` with `=` — this makes line 51 consistent

## Test plan
- [x] YAML validation passes
- [ ] CI workflow runs successfully

Closes #28