### PR TITLE
fix: make random selector highlight more visible

### DIFF
--- a/css_generator.py
+++ b/css_generator.py
@@ -721,12 +721,20 @@ def generate_css():
     }
 
     @keyframes random-highlight {
-      0%, 100% { background: transparent; }
-      50% { background: rgba(102, 126, 234, 0.3); }
+      0% { background: transparent; }
+      10% { background: rgba(255,215,0,0.85); }
+      20% { background: transparent; }
+      30% { background: rgba(255,215,0,0.85); }
+      40% { background: transparent; }
+      50% { background: rgba(255,215,0,0.85); }
+      60%, 80% { background: rgba(255,215,0,0.4); }
+      100% { background: transparent; }
     }
 
     .random-highlight {
-      animation: random-highlight 2s ease;
+      animation: random-highlight 4s ease forwards;
+      border-left: 4px solid #f6c90e;
+      box-shadow: inset 4px 0 0 rgba(246,201,14,0.3);
     }
 
     .table-container {

--- a/js_core_generator.py
+++ b/js_core_generator.py
@@ -565,7 +565,7 @@ def generate_js_core():
       Array.from(tbody.querySelectorAll('tr')).forEach(r => r.classList.remove('random-highlight'));
       selectedRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
       selectedRow.classList.add('random-highlight');
-      setTimeout(() => selectedRow.classList.remove('random-highlight'), 2000);
+      setTimeout(() => selectedRow.classList.remove('random-highlight'), 4000);
     }
 
     // Enable or disable the random button based on visible row count


### PR DESCRIPTION
## Summary
- Replace faint single-pulse highlight with bright gold multi-flash animation
- Add solid left-border accent (#f6c90e) for immediate visual identification
- Extend animation duration from 2s to 4s
- Three bright flashes + warm glow hold before fade-out

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] CI passes
- [ ] Manual: click Random, verify bright gold flash is unmistakable

Fixes #44