### PR TITLE
fix: resolve awareness color refresh reliability issues

### DIFF
--- a/js_awareness_generator.py
+++ b/js_awareness_generator.py
@@ -376,6 +376,7 @@ def generate_js_awareness():
     // Manual refresh function (can be called from button)
     function manualRefreshAwareness() {
       updateAwarenessColors(true);  // Update all tabs for manual refresh
+      PROBLEM_DATA.file_list.forEach(function(fileKey) { if (typeof applyFilters === 'function') applyFilters(fileKey); });
     }
 
     // Initialize awareness on load

--- a/js_core_generator.py
+++ b/js_core_generator.py
@@ -25,13 +25,13 @@ def generate_js_core():
         showStorageToast('localStorage is not available. Your progress will not be saved.', 'warning');
       }
       loadFromLocalStorage();
-      initAwareness();
       populatePatternFilters();
       PROBLEM_DATA.file_list.forEach(fileKey => {
         PROBLEM_DATA.data[fileKey].forEach((problem, idx) => { problem._originalIndex = idx; });
         restoreSortStateForTab(fileKey);
       });
       renderAllTabs();
+      initAwareness();
       updateAllProgress();
       PROBLEM_DATA.file_list.forEach(fileKey => {
         updateRandomBtnState(fileKey);


### PR DESCRIPTION
## Summary
- Fix init order: move initAwareness() after renderAllTabs() so awareness classes are applied to existing rows
- Fix stale filter: re-apply filters after manual awareness refresh so color filter reflects updated classes

## Root causes
1. initAwareness() ran before rows existed in DOM — no classes applied
2. manualRefreshAwareness() updated classes but never re-applied active color filter

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] CI passes
- [ ] Manual: verify colors update on refresh button click
- [ ] Manual: verify color filter works after refresh

Fixes #38