### PR TITLE
fix: prioritize current awareness tier in urgent review filter

### DIFF
--- a/js_core_generator.py
+++ b/js_core_generator.py
@@ -598,19 +598,27 @@ def generate_js_core():
 
     // Apply urgent review filter: show only the most urgently-due solved problems
     function applyUrgentReviewFilter(fileKey) {
+      const TIER_RANK = { 'awareness-flashing': 5, 'awareness-dark-red': 4, 'awareness-red': 3, 'awareness-yellow': 2, 'awareness-green': 1, 'awareness-white': 0, 'unsolved-problem': -1 };
       const problems = PROBLEM_DATA.data[fileKey];
       const tbody = document.getElementById(`tbody-${fileKey}`);
       if (!tbody) return;
 
       const solvedProblems = problems
-        .map((problem, idx) => ({ idx, days: calculateDaysUntilFlashing(problem) }))
-        .filter(item => item.days !== Infinity);
+        .map((problem, idx) => {
+          const days = calculateDaysUntilFlashing(problem);
+          if (days === Infinity) return null;
+          const scoreResult = calculateAwarenessScore(problem);
+          const tier = TIER_RANK[getAwarenessClass(scoreResult.score)] || 0;
+          return { idx, days, tier };
+        })
+        .filter(item => item !== null);
 
       if (solvedProblems.length === 0) return;
 
-      const minDays = Math.min(...solvedProblems.map(item => item.days));
+      const maxTier = Math.max(...solvedProblems.map(item => item.tier));
+      const globalMinDays = Math.min(...solvedProblems.map(item => item.days));
       const urgentIndices = new Set(
-        solvedProblems.filter(item => item.days === minDays).map(item => item.idx)
+        solvedProblems.filter(item => item.tier === maxTier || item.days === globalMinDays).map(item => item.idx)
       );
 
       const rows = tbody.querySelectorAll('tr');
@@ -625,9 +633,9 @@ def generate_js_core():
       const count = urgentIndices.size;
       const statusEl = document.getElementById(`progress-text-${fileKey}`);
       if (statusEl) {
-        const msg = minDays === 0
+        const msg = globalMinDays === 0
           ? `${count} problem(s) flashing NOW`
-          : `${count} problem(s) flashing in ${minDays} day(s)`;
+          : `${count} problem(s) flashing in ${globalMinDays} day(s)`;
         statusEl.textContent = msg;
       }
     }

--- a/tests/urgent-review.js
+++ b/tests/urgent-review.js
@@ -10,6 +10,7 @@
 
 import {
   calculateAwarenessScore,
+  getAwarenessClass,
   getCommitmentFactor,
   getTierDifficultyMultiplier,
   getSolvedFactor,
@@ -18,6 +19,8 @@ import {
   resetConfig,
   setConfig
 } from './awareness.js';
+
+export const TIER_RANK = { 'awareness-flashing': 5, 'awareness-dark-red': 4, 'awareness-red': 3, 'awareness-yellow': 2, 'awareness-green': 1, 'awareness-white': 0, 'unsolved-problem': -1 };
 
 // ── Injectable state for testing ─────────────────────────────────────────────
 
@@ -71,18 +74,30 @@ export function calculateDaysUntilFlashing(problem) {
  * @param {Array} deps.problems - Problem array for this fileKey
  * @param {Array} deps.rows - Row objects with style.display and dataset.index
  * @param {Object|null} deps.statusEl - Element with .textContent for status message
- * @returns {{ minDays: number, urgentIndices: Set<number> }|null} null if no solved problems
+ * @param {Function} [deps.getAwarenessClassFn] - Injectable getAwarenessClass for testing
+ * @param {Function} [deps.calculateAwarenessScoreFn] - Injectable calculateAwarenessScore for testing
+ * @returns {{ globalMinDays: number, urgentIndices: Set<number> }|null} null if no solved problems
  */
-export function applyUrgentReviewFilter(fileKey, { problems, rows, statusEl }) {
+export function applyUrgentReviewFilter(fileKey, { problems, rows, statusEl, getAwarenessClassFn, calculateAwarenessScoreFn }) {
+  const _getAwarenessClass = getAwarenessClassFn || getAwarenessClass;
+  const _calculateAwarenessScore = calculateAwarenessScoreFn || calculateAwarenessScore;
+
   const solvedProblems = problems
-    .map((problem, idx) => ({ idx, days: calculateDaysUntilFlashing(problem) }))
-    .filter(item => item.days !== Infinity);
+    .map((problem, idx) => {
+      const days = calculateDaysUntilFlashing(problem);
+      if (days === Infinity) return null;
+      const scoreResult = _calculateAwarenessScore(problem);
+      const tier = TIER_RANK[_getAwarenessClass(scoreResult.score)] || 0;
+      return { idx, days, tier };
+    })
+    .filter(item => item !== null);
 
   if (solvedProblems.length === 0) return null;
 
-  const minDays = Math.min(...solvedProblems.map(item => item.days));
+  const maxTier = Math.max(...solvedProblems.map(item => item.tier));
+  const globalMinDays = Math.min(...solvedProblems.map(item => item.days));
   const urgentIndices = new Set(
-    solvedProblems.filter(item => item.days === minDays).map(item => item.idx)
+    solvedProblems.filter(item => item.tier === maxTier || item.days === globalMinDays).map(item => item.idx)
   );
 
   rows.forEach(row => {
@@ -92,13 +107,13 @@ export function applyUrgentReviewFilter(fileKey, { problems, rows, statusEl }) {
 
   if (statusEl) {
     const count = urgentIndices.size;
-    const msg = minDays === 0
+    const msg = globalMinDays === 0
       ? `${count} problem(s) flashing NOW`
-      : `${count} problem(s) flashing in ${minDays} day(s)`;
+      : `${count} problem(s) flashing in ${globalMinDays} day(s)`;
     statusEl.textContent = msg;
   }
 
-  return { minDays, urgentIndices };
+  return { globalMinDays, urgentIndices };
 }
 
 // ── updateUrgentBtnState ──────────────────────────────────────────────────────

--- a/tests/urgent-review.test.js
+++ b/tests/urgent-review.test.js
@@ -9,7 +9,8 @@ import {
   setMockProblemData,
   resetState,
   setConfig,
-  getConfig
+  getConfig,
+  TIER_RANK
 } from './urgent-review.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -233,7 +234,7 @@ describe('Most Urgent Review Filter', () => {
 
       const result = applyUrgentReviewFilter('test', { problems, rows, statusEl: null });
 
-      expect(result.minDays).toBe(0);
+      expect(result.globalMinDays).toBe(0);
       expect(result.urgentIndices.has(0)).toBe(true);
       expect(result.urgentIndices.has(1)).toBe(false);
     });
@@ -290,13 +291,94 @@ describe('Most Urgent Review Filter', () => {
 
       const result = applyUrgentReviewFilter('test', { problems, rows, statusEl: null });
 
-      expect(result.minDays).toBeGreaterThanOrEqual(0);
-      expect(isFinite(result.minDays)).toBe(true);
+      expect(result.globalMinDays).toBeGreaterThanOrEqual(0);
+      expect(isFinite(result.globalMinDays)).toBe(true);
     });
 
     it('returns null for empty problem list', () => {
       const result = applyUrgentReviewFilter('test', { problems: [], rows: [], statusEl: null });
       expect(result).toBeNull();
+    });
+
+    it('red problem shown even when yellows have fewer days', () => {
+      const problems = [
+        makeProblem({ name: 'Red', solved_date: dateAgo(60) }),
+        makeProblem({ name: 'Yellow1', solved_date: dateAgo(10) }),
+        makeProblem({ name: 'Yellow2', solved_date: dateAgo(12) })
+      ];
+      const rows = [makeRow(0), makeRow(1), makeRow(2)];
+
+      const mockGetAwarenessClass = (score) => {
+        if (score >= 90) return 'awareness-dark-red';
+        if (score >= 70) return 'awareness-red';
+        if (score >= 50) return 'awareness-yellow';
+        if (score >= 30) return 'awareness-green';
+        return 'awareness-white';
+      };
+      const mockCalcScore = (problem) => {
+        const days = (Date.now() - new Date(problem.solved_date).getTime()) / 86400000;
+        return { score: Math.min(days, 100), invalidDate: false };
+      };
+
+      const result = applyUrgentReviewFilter('test', {
+        problems, rows, statusEl: null,
+        getAwarenessClassFn: mockGetAwarenessClass,
+        calculateAwarenessScoreFn: mockCalcScore
+      });
+
+      expect(result).not.toBeNull();
+      expect(result.urgentIndices.has(0)).toBe(true);
+    });
+
+    it('flashing problem always included regardless of days', () => {
+      const problems = [
+        makeProblem({ name: 'Flashing', solved_date: dateAgo(200) }),
+        makeProblem({ name: 'Yellow1', solved_date: dateAgo(5) }),
+        makeProblem({ name: 'Yellow2', solved_date: dateAgo(8) })
+      ];
+      const rows = [makeRow(0), makeRow(1), makeRow(2)];
+
+      const mockGetAwarenessClass = (score) => {
+        if (score >= 90) return 'awareness-flashing';
+        if (score >= 50) return 'awareness-yellow';
+        return 'awareness-white';
+      };
+      const mockCalcScore = (problem) => {
+        const days = (Date.now() - new Date(problem.solved_date).getTime()) / 86400000;
+        return { score: Math.min(days, 200), invalidDate: false };
+      };
+
+      const result = applyUrgentReviewFilter('test', {
+        problems, rows, statusEl: null,
+        getAwarenessClassFn: mockGetAwarenessClass,
+        calculateAwarenessScoreFn: mockCalcScore
+      });
+
+      expect(result).not.toBeNull();
+      expect(result.urgentIndices.has(0)).toBe(true);
+    });
+
+    it('only yellows — shows min-days yellow same as before', () => {
+      const problems = [
+        makeProblem({ name: 'Yellow1', solved_date: dateAgo(20) }),
+        makeProblem({ name: 'Yellow2', solved_date: dateAgo(5) }),
+        makeProblem({ name: 'Yellow3', solved_date: dateAgo(5) })
+      ];
+      const rows = [makeRow(0), makeRow(1), makeRow(2)];
+
+      const mockGetAwarenessClass = (_score) => 'awareness-yellow';
+      const mockCalcScore = (problem) => ({ score: 50, invalidDate: false });
+
+      const result = applyUrgentReviewFilter('test', {
+        problems, rows, statusEl: null,
+        getAwarenessClassFn: mockGetAwarenessClass,
+        calculateAwarenessScoreFn: mockCalcScore
+      });
+
+      expect(result).not.toBeNull();
+      expect(result.urgentIndices.has(0)).toBe(true);
+      expect(result.urgentIndices.has(1)).toBe(true);
+      expect(result.urgentIndices.has(2)).toBe(true);
     });
 
   });


### PR DESCRIPTION
## Summary
- Urgent review filter now shows all problems in the highest current awareness tier
- Additionally includes any lower-tier problems tied at minimum days-until-flashing
- Fixes case where red problems were hidden because yellows had fewer days until flashing

## Test plan
- [x] Build succeeds
- [x] All tests pass (including new tier-priority tests)
- [ ] CI passes
- [ ] Manual: verify red problems shown alongside urgent yellows

Fixes #46