### PR TITLE
fix: add toggle and shorten urgent review button

### DIFF
--- a/css_generator.py
+++ b/css_generator.py
@@ -699,7 +699,7 @@ def generate_css():
     }
 
     .urgent-review-btn {
-      padding: 12px 24px;
+      padding: 8px 16px;
       background: #e53e3e;
       color: white;
       border: none;
@@ -713,6 +713,11 @@ def generate_css():
 
     .urgent-review-btn:hover {
       background: #c53030;
+    }
+
+    .urgent-review-btn.active {
+      background: #9b2c2c;
+      border: 2px solid #fc8181;
     }
 
     .urgent-review-btn:disabled {

--- a/html_generator.py
+++ b/html_generator.py
@@ -72,7 +72,7 @@ def generate_html_structure(file_list, firebase_enabled=False):
 
         <button id="random-btn-{file_name}" class="random-btn" onclick="pickRandomProblem('{file_name}')" aria-label="Pick a random problem from filtered list">&#127922; Random</button>
 
-        <button id="urgent-review-btn-{file_name}" class="urgent-review-btn" onclick="applyUrgentReviewFilter('{file_name}')" aria-label="Most Urgent Review">&#128680; Most Urgent Review</button>
+        <button id="urgent-review-btn-{file_name}" class="urgent-review-btn" onclick="applyUrgentReviewFilter('{file_name}')" aria-label="Most Urgent Review">&#128680; URGENT</button>
 
         <div class="import-export-wrapper">
           <button class="hamburger-btn" onclick="toggleImportExportMenu('{file_name}')" aria-label="Import/Export Menu" aria-expanded="false">

--- a/js_core_generator.py
+++ b/js_core_generator.py
@@ -440,6 +440,9 @@ def generate_js_core():
 
     // Apply filters
     function applyFilters(fileKey) {
+      const urgentBtn = document.getElementById(`urgent-review-btn-${fileKey}`);
+      if (urgentBtn) urgentBtn.classList.remove('active');
+
       const searchTerm = document.getElementById(`search-${fileKey}`).value.toLowerCase();
       const difficultyFilter = document.getElementById(`difficulty-filter-${fileKey}`).value;
       const patternFilter = document.getElementById(`pattern-filter-${fileKey}`).value;
@@ -598,6 +601,13 @@ def generate_js_core():
 
     // Apply urgent review filter: show only the most urgently-due solved problems
     function applyUrgentReviewFilter(fileKey) {
+      const btn = document.getElementById(`urgent-review-btn-${fileKey}`);
+      if (btn && btn.classList.contains('active')) {
+        btn.classList.remove('active');
+        applyFilters(fileKey);
+        return;
+      }
+
       const TIER_RANK = { 'awareness-flashing': 5, 'awareness-dark-red': 4, 'awareness-red': 3, 'awareness-yellow': 2, 'awareness-green': 1, 'awareness-white': 0, 'unsolved-problem': -1 };
       const problems = PROBLEM_DATA.data[fileKey];
       const tbody = document.getElementById(`tbody-${fileKey}`);
@@ -627,6 +637,7 @@ def generate_js_core():
         row.style.display = urgentIndices.has(idx) ? '' : 'none';
       });
 
+      if (btn) btn.classList.add('active');
       updateRandomBtnState(fileKey);
       updateUrgentBtnState(fileKey);
 


### PR DESCRIPTION
## Summary
- Urgent review button now toggles: click to activate filter, click again to clear
- Button text shortened to '🚨 URGENT' for smaller footprint
- Active state styling shows when filter is engaged
- Filter auto-clears when other filter dropdowns are changed

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] CI passes
- [ ] Manual: verify toggle on/off
- [ ] Manual: verify filter clears on dropdown change

Fixes #46