### PR TITLE
fix: revert progress text when toggling urgent filter off

### DIFF
--- a/js_core_generator.py
+++ b/js_core_generator.py
@@ -605,6 +605,7 @@ def generate_js_core():
       if (btn && btn.classList.contains('active')) {
         btn.classList.remove('active');
         applyFilters(fileKey);
+        updateProgress(fileKey);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Restore standard progress text when urgent review filter is toggled off
- Previously the urgent message persisted after deactivating the filter

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] CI passes
- [ ] Manual: toggle urgent filter on then off, verify progress text reverts

Fixes #46