### PR TITLE
fix: show burger menus when problem list has few filtered results

### DIFF
--- a/css_generator.py
+++ b/css_generator.py
@@ -148,6 +148,7 @@ def generate_css():
       position: relative;
       display: inline-block;
       margin-left: auto;
+      z-index: 1;
     }
 
     /* Hamburger button */

--- a/css_generator.py
+++ b/css_generator.py
@@ -40,13 +40,14 @@ def generate_css():
       background: white;
       border-radius: 12px;
       box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
-      overflow: hidden;
+      overflow: visible;
     }
 
     header {
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       color: white;
       padding: 20px 30px;
+      border-radius: 12px 12px 0 0;
     }
 
     .header-content {

--- a/css_generator.py
+++ b/css_generator.py
@@ -148,7 +148,7 @@ def generate_css():
       position: relative;
       display: inline-block;
       margin-left: auto;
-      z-index: 1;
+      z-index: 11;
     }
 
     /* Hamburger button */


### PR DESCRIPTION
## Summary

- Changed `.container` from `overflow: hidden` to `overflow: visible` so burger menu dropdowns are not clipped by the container bounds
- Added `border-radius` directly to the header element to preserve rounded corners that were previously relying on container's `overflow: hidden`

Fixes #37

## Test plan

- [ ] Apply filters to reduce problem list to 0-1 problems — verify general export/import burger menu is visible and functional
- [ ] Apply filters to reduce problem list to 0-3 problems — verify tab export/import burger menu is visible and functional
- [ ] Verify container still has rounded corners with normal problem counts
- [ ] Verify burger menu dropdowns open correctly in all cases